### PR TITLE
Ensure no response is sent to messages that don't require a response

### DIFF
--- a/internal/metrics/feature.go
+++ b/internal/metrics/feature.go
@@ -141,7 +141,7 @@ func (m *Metrics) messageHandler(requestID string, msg *protocol.Envelope) {
 		if msg.Path == pathMetricsRequest {
 			correlationID := msg.Headers.CorrelationID()
 			msgErr := m.handleMessageRequest(msg, correlationID)
-			if len(correlationID) > 0 {
+			if msg.Headers.IsResponseRequired() {
 				m.sendReply(requestID, correlationID, string(msg.Topic.Action), msgErr)
 			}
 		} else {

--- a/internal/metrics/feature_test.go
+++ b/internal/metrics/feature_test.go
@@ -187,7 +187,11 @@ func TestHandleRequestPublishedMessages(t *testing.T) {
 		WithPayload(&Request{
 			Frequency: Duration{1 * time.Second},
 		})
-	metrics.client.Send(msg.Inbox(testOperationRequest).Envelope(protocol.WithCorrelationID("request_1")))
+
+	metrics.client.Send(msg.Inbox(testOperationRequest).
+		Envelope(protocol.WithResponseRequired(true),
+			protocol.WithCorrelationID("request_1")))
+
 	assertReplyStatusOK(t, mc)
 	assertDefaultMetricData(t, mc)
 
@@ -196,7 +200,11 @@ func TestHandleRequestPublishedMessages(t *testing.T) {
 		WithPayload(&Request{
 			Frequency: Duration{0 * time.Second},
 		})
-	metrics.client.Send(msgStop.Inbox(testOperationRequest).Envelope(protocol.WithCorrelationID("request_stop")))
+
+	metrics.client.Send(msgStop.Inbox(testOperationRequest).
+		Envelope(protocol.WithResponseRequired(true),
+			protocol.WithCorrelationID("request_stop")))
+
 	assertReplyStatusOK(t, mc)
 	assertNoMetricData(t, mc)
 
@@ -210,7 +218,11 @@ func TestHandleRequestInvalidFrequency(t *testing.T) {
 	msg := things.NewMessage(model.NewNamespacedIDFrom(testThingID)).
 		Feature(featureID).
 		WithPayload("{'frequency':'invalid_duration'}")
-	metrics.client.Send(msg.Inbox(testOperationRequest).Envelope(protocol.WithCorrelationID("request_invalid_duration")))
+
+	metrics.client.Send(msg.Inbox(testOperationRequest).
+		Envelope(protocol.WithResponseRequired(true),
+			protocol.WithCorrelationID("request_invalid_duration")))
+
 	receivedMsg := mc.value(t)
 	format := "expected message error %v but is: %v"
 	if receivedMsg == nil {

--- a/internal/metrics/feature_test.go
+++ b/internal/metrics/feature_test.go
@@ -177,6 +177,23 @@ func TestReplyOK(t *testing.T) {
 	}
 }
 
+func TestNoResponseRequiredSet(t *testing.T) {
+	metrics, mc := testInit()
+	doTestConnection(metrics, mc)
+	assertNoMetricData(t, mc)
+
+	msg := things.NewMessage(model.NewNamespacedIDFrom(testThingID)).
+		Feature(featureID).
+		WithPayload(&Request{
+			Frequency: Duration{1 * time.Second},
+		})
+
+	metrics.client.Send(msg.Inbox(testOperationRequest).
+		Envelope(protocol.WithCorrelationID("request_no_response")))
+
+	assertDefaultMetricData(t, mc)
+}
+
 func TestHandleRequestPublishedMessages(t *testing.T) {
 	metrics, mc := testInit()
 	doTestConnection(metrics, mc)

--- a/internal/metrics/feature_test.go
+++ b/internal/metrics/feature_test.go
@@ -189,9 +189,21 @@ func TestNoResponseRequiredSet(t *testing.T) {
 		})
 
 	metrics.client.Send(msg.Inbox(testOperationRequest).
-		Envelope(protocol.WithCorrelationID("request_no_response")))
+		Envelope(protocol.WithCorrelationID("request_start_no_response")))
 
 	assertDefaultMetricData(t, mc)
+
+	msgStop := things.NewMessage(model.NewNamespacedIDFrom(testThingID)).
+		Feature(featureID).
+		WithPayload(&Request{
+			Frequency: Duration{0 * time.Second},
+		})
+
+	metrics.client.Send(msgStop.Inbox(testOperationRequest).
+		Envelope(protocol.WithCorrelationID("request_stop_no_response")))
+
+	assertNoMetricData(t, mc)
+	metricsClose(t, metrics, mc)
 }
 
 func TestHandleRequestPublishedMessages(t *testing.T) {


### PR DESCRIPTION
[#20] Ensure no response is sent to messages that don't require a response

Ensured no reply is sent to messages that don't require a response, based on their response-required header.

Signed-off-by: Gabriela Yoncheva <Gabriela.Yoncheva@bosch.io>